### PR TITLE
Add nsswitch.conf file into the image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -8,6 +8,7 @@ RUN set -ex; \
 		x86_64) arch='amd64' ;; \
 		*) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
 	esac; \
+	[ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf ; \
 	wget --quiet -O /usr/local/bin/traefik "https://github.com/containous/traefik/releases/download/v1.7.12/traefik_linux-$arch"; \
 	chmod +x /usr/local/bin/traefik
 COPY entrypoint.sh /

--- a/alpine/tmplv1.Dockerfile
+++ b/alpine/tmplv1.Dockerfile
@@ -8,6 +8,7 @@ RUN set -ex; \
 		x86_64) arch='amd64' ;; \
 		*) echo >&2 "error: unsupported architecture: ${DOLLAR}apkArch"; exit 1 ;; \
 	esac; \
+	[ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf ; \
 	wget --quiet -O /usr/local/bin/traefik "https://github.com/containous/traefik/releases/download/$VERSION/traefik_linux-${DOLLAR}arch"; \
 	chmod +x /usr/local/bin/traefik
 COPY entrypoint.sh /

--- a/scratch/amd64/Dockerfile
+++ b/scratch/amd64/Dockerfile
@@ -1,5 +1,6 @@
 FROM scratch
 COPY certs/ca-certificates.crt /etc/ssl/certs/
+COPY /etc/nsswitch.conf /etc/
 COPY traefik /
 EXPOSE 80
 VOLUME ["/tmp"]

--- a/scratch/amd64/etc/nsswitch.conf
+++ b/scratch/amd64/etc/nsswitch.conf
@@ -1,0 +1,1 @@
+hosts:          files dns

--- a/scratch/arm/Dockerfile
+++ b/scratch/arm/Dockerfile
@@ -1,5 +1,6 @@
 FROM scratch
 COPY certs/ca-certificates.crt /etc/ssl/certs/
+COPY /etc/nsswitch.conf /etc/
 COPY traefik /
 EXPOSE 80
 VOLUME ["/tmp"]

--- a/scratch/arm/etc/nsswitch.conf
+++ b/scratch/arm/etc/nsswitch.conf
@@ -1,0 +1,1 @@
+hosts:          files dns

--- a/scratch/arm64/Dockerfile
+++ b/scratch/arm64/Dockerfile
@@ -1,5 +1,6 @@
 FROM scratch
 COPY certs/ca-certificates.crt /etc/ssl/certs/
+COPY /etc/nsswitch.conf /etc/
 COPY traefik /
 EXPOSE 80
 VOLUME ["/tmp"]

--- a/scratch/arm64/etc/nsswitch.conf
+++ b/scratch/arm64/etc/nsswitch.conf
@@ -1,0 +1,1 @@
+hosts:          files dns

--- a/scratch/tmpl.Dockerfile
+++ b/scratch/tmpl.Dockerfile
@@ -1,5 +1,6 @@
 FROM scratch
 COPY certs/ca-certificates.crt /etc/ssl/certs/
+COPY /etc/nsswitch.conf /etc/
 COPY traefik /
 EXPOSE 80
 VOLUME ["/tmp"]


### PR DESCRIPTION
This fixes an issue I've encountered - the absence of `/etc/nsswitch.conf` makes traefik ignore the `/etc/hosts` file inside the container. For reference see [here](https://github.com/golang/go/issues/22846#issuecomment-433970889) and [here for alpine](https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460).

This is very surprising and often painful in some scenarios like [this one](https://stackoverflow.com/questions/49476452/traefik-forwarding-to-a-host-and-overriding-ip/53446860?noredirect=1). But I suppose any user that is trying to use `--add-host` docker flag in lieu of DNS entry for whatever reason is going to be burned by that.

The `nsswitch.conf` file added is default configuration found in most distributions I've seen. I've used it for completeness as that's the one distroless base image is using, but just having this one line in would alleviate the specific problem:

```
hosts:          files dns
```

I can modify the PR if you prefer that format. 

Hope that helps.