### PR TITLE
-BREAKING- Update base image to not run as root

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -11,9 +11,10 @@ RUN set -ex; \
 	wget --quiet -O /usr/local/bin/traefik "https://github.com/containous/traefik/releases/download/v1.7.5/traefik_linux-$arch"; \
 	chmod +x /usr/local/bin/traefik
 COPY entrypoint.sh /
-EXPOSE 80
+EXPOSE 8080
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["traefik"]
+USER 1001:1001
 
 # Metadata
 LABEL org.label-schema.vendor="Containous" \

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Default to a higher port. Can be overridden by specifying the --entrypoints="Name:http Address::<PORT>" again.
+set -- --entrypoints="Name:http Address::8080" "$@"
+
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
     set -- traefik "$@"

--- a/alpine/tmpl.Dockerfile
+++ b/alpine/tmpl.Dockerfile
@@ -11,9 +11,10 @@ RUN set -ex; \
 	wget --quiet -O /usr/local/bin/traefik "https://github.com/containous/traefik/releases/download/$VERSION/traefik_linux-${DOLLAR}arch"; \
 	chmod +x /usr/local/bin/traefik
 COPY entrypoint.sh /
-EXPOSE 80
+EXPOSE 8080
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["traefik"]
+USER 1001:1001
 
 # Metadata
 LABEL org.label-schema.vendor="Containous" \

--- a/scratch/amd64/Dockerfile
+++ b/scratch/amd64/Dockerfile
@@ -1,9 +1,10 @@
 FROM scratch
 COPY certs/ca-certificates.crt /etc/ssl/certs/
 COPY traefik /
-EXPOSE 80
+EXPOSE 8080
 VOLUME ["/tmp"]
 ENTRYPOINT ["/traefik"]
+CMD ["--entrypoints=Name:http Address::8080"]
 
 # Metadata
 LABEL org.label-schema.vendor="Containous" \

--- a/scratch/arm/Dockerfile
+++ b/scratch/arm/Dockerfile
@@ -1,9 +1,10 @@
 FROM scratch
 COPY certs/ca-certificates.crt /etc/ssl/certs/
 COPY traefik /
-EXPOSE 80
+EXPOSE 8080
 VOLUME ["/tmp"]
 ENTRYPOINT ["/traefik"]
+CMD ["--entrypoints=Name:http Address::8080"]
 
 # Metadata
 LABEL org.label-schema.vendor="Containous" \

--- a/scratch/arm64/Dockerfile
+++ b/scratch/arm64/Dockerfile
@@ -1,9 +1,10 @@
 FROM scratch
 COPY certs/ca-certificates.crt /etc/ssl/certs/
 COPY traefik /
-EXPOSE 80
+EXPOSE 8080
 VOLUME ["/tmp"]
 ENTRYPOINT ["/traefik"]
+CMD ["--entrypoints=Name:http Address::8080"]
 
 # Metadata
 LABEL org.label-schema.vendor="Containous" \

--- a/scratch/tmpl.Dockerfile
+++ b/scratch/tmpl.Dockerfile
@@ -1,9 +1,10 @@
 FROM scratch
 COPY certs/ca-certificates.crt /etc/ssl/certs/
 COPY traefik /
-EXPOSE 80
+EXPOSE 8080
 VOLUME ["/tmp"]
 ENTRYPOINT ["/traefik"]
+CMD ["--entrypoints=Name:http Address::8080"]
 
 # Metadata
 LABEL org.label-schema.vendor="Containous" \


### PR DESCRIPTION

### Do you want to request a *feature* or report a *bug*?

Feature

### What did you do?

Ran Traefik with a Kubernetes Pod Security Policy disallowing running containers as root. It did not start.

### What did you expect to see?

Traefik would run without issue

### What did you see instead?

Traffik would not start. The image runs as root - Running with a specified user does not work because it attempts to bind port 80. With a custom configuration that does not bind port 80, however, the image runs just fine.

This change alters the image to expose port 8080 instead, and adds a USER stanza to not run as root. This is a breaking change for many users, and would require significant announcement - I'm proposing it as a discussion topic rather than as an immediate merge target.