### PR TITLE
Add image support for various arm archs (v5,6,7)

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -4,6 +4,7 @@ RUN set -ex; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
 		armhf) arch='armv6' ;; \
+		armv[567]) arch="$apkArch" ;; \
 		aarch64) arch='arm64' ;; \
 		x86_64) arch='amd64' ;; \
 		*) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \


### PR DESCRIPTION
### What does this PR do?

This PR adds native build support for the arch architectures v5, v6, v7 in that it checks versions more fine-grainedly and references official traefik binaries for those versions.


### Motivation

It was not possible for me to run the docker build on my Raspberry Pi 3 because `apk --print-arch` spits out 'armv7', but the bash case operation only allows the generic 'armhf', which in turn results in the backwards-compatible 'armv6' binary.
As Traefik actually releases binaries for particular arm architectures, specifically armv7 needed here, I updated the Dockerfile to make local builds possible.
This should not interfere with the build-pipeline at all, though I would appreciate the addition of armv7 images.