### PR TITLE
Add Dockerfiles and update build files for additional Windows versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,8 @@ environment:
       PLATFORM_DIR: ./windows/1903/
     - PLATFORM: windows-1909
       PLATFORM_DIR: ./windows/1909/
+    - PLATFORM: windows-2004
+      PLATFORM_DIR: ./windows/2004/
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,10 @@ environment:
   matrix:
     - PLATFORM: windows-1809
       PLATFORM_DIR: ./windows/1809/
-
+    - PLATFORM: windows-1903
+      PLATFORM_DIR: ./windows/1903/
+    - PLATFORM: windows-1909
+      PLATFORM_DIR: ./windows/1909/
 
 matrix:
   fast_finish: true

--- a/update.sh
+++ b/update.sh
@@ -16,6 +16,7 @@ PLATFORMS=(
 	"windows/1809"
 	"windows/1903"
 	"windows/1909"
+	"windows/2004"
 )
 
 SCRIPT_DIRNAME_ABSOLUTEPATH="$(cd "$(dirname "$0")" && pwd -P)"

--- a/update.sh
+++ b/update.sh
@@ -14,6 +14,8 @@ PLATFORMS=(
 	"alpine"
 	"scratch"
 	"windows/1809"
+	"windows/1903"
+	"windows/1909"
 )
 
 SCRIPT_DIRNAME_ABSOLUTEPATH="$(cd "$(dirname "$0")" && pwd -P)"

--- a/windows/1903/Dockerfile
+++ b/windows/1903/Dockerfile
@@ -1,0 +1,20 @@
+
+FROM mcr.microsoft.com/windows/servercore:1903
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+    -Uri "https://github.com/containous/traefik/releases/download/v2.2.1/traefik_v2.2.1_windows_amd64.zip" \
+    -OutFile "/traefik.zip"; \
+    Expand-Archive -Path "/traefik.zip" -DestinationPath "/" -Force; \
+    Remove-Item "/traefik.zip" -Force
+
+EXPOSE 80
+ENTRYPOINT ["/traefik"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Containous" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="v2.2.1" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/windows/1903/tmplv1.Dockerfile
+++ b/windows/1903/tmplv1.Dockerfile
@@ -1,0 +1,18 @@
+
+FROM mcr.microsoft.com/windows/servercore:1903
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+    -Uri "https://github.com/containous/traefik/releases/download/${VERSION}/traefik_windows-amd64.exe" \
+    -OutFile "/traefik.exe"
+
+EXPOSE 80
+ENTRYPOINT ["/traefik"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Containous" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="$VERSION" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/windows/1903/tmplv2.Dockerfile
+++ b/windows/1903/tmplv2.Dockerfile
@@ -1,0 +1,20 @@
+
+FROM mcr.microsoft.com/windows/servercore:1903
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+    -Uri "https://github.com/containous/traefik/releases/download/${VERSION}/traefik_${VERSION}_windows_amd64.zip" \
+    -OutFile "/traefik.zip"; \
+    Expand-Archive -Path "/traefik.zip" -DestinationPath "/" -Force; \
+    Remove-Item "/traefik.zip" -Force
+
+EXPOSE 80
+ENTRYPOINT ["/traefik"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Containous" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="$VERSION" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/windows/1909/Dockerfile
+++ b/windows/1909/Dockerfile
@@ -1,0 +1,20 @@
+
+FROM mcr.microsoft.com/windows/servercore:1909
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+    -Uri "https://github.com/containous/traefik/releases/download/v2.2.1/traefik_v2.2.1_windows_amd64.zip" \
+    -OutFile "/traefik.zip"; \
+    Expand-Archive -Path "/traefik.zip" -DestinationPath "/" -Force; \
+    Remove-Item "/traefik.zip" -Force
+
+EXPOSE 80
+ENTRYPOINT ["/traefik"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Containous" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="v2.2.1" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/windows/1909/tmplv1.Dockerfile
+++ b/windows/1909/tmplv1.Dockerfile
@@ -1,0 +1,18 @@
+
+FROM mcr.microsoft.com/windows/servercore:1909
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+    -Uri "https://github.com/containous/traefik/releases/download/${VERSION}/traefik_windows-amd64.exe" \
+    -OutFile "/traefik.exe"
+
+EXPOSE 80
+ENTRYPOINT ["/traefik"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Containous" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="$VERSION" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/windows/1909/tmplv2.Dockerfile
+++ b/windows/1909/tmplv2.Dockerfile
@@ -1,0 +1,20 @@
+
+FROM mcr.microsoft.com/windows/servercore:1909
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+    -Uri "https://github.com/containous/traefik/releases/download/${VERSION}/traefik_${VERSION}_windows_amd64.zip" \
+    -OutFile "/traefik.zip"; \
+    Expand-Archive -Path "/traefik.zip" -DestinationPath "/" -Force; \
+    Remove-Item "/traefik.zip" -Force
+
+EXPOSE 80
+ENTRYPOINT ["/traefik"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Containous" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="$VERSION" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/windows/2004/Dockerfile
+++ b/windows/2004/Dockerfile
@@ -1,0 +1,20 @@
+
+FROM mcr.microsoft.com/windows/servercore:2004
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+    -Uri "https://github.com/containous/traefik/releases/download/v2.2.1/traefik_v2.2.1_windows_amd64.zip" \
+    -OutFile "/traefik.zip"; \
+    Expand-Archive -Path "/traefik.zip" -DestinationPath "/" -Force; \
+    Remove-Item "/traefik.zip" -Force
+
+EXPOSE 80
+ENTRYPOINT ["/traefik"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Containous" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="v2.2.1" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/windows/2004/tmplv1.Dockerfile
+++ b/windows/2004/tmplv1.Dockerfile
@@ -1,0 +1,18 @@
+
+FROM mcr.microsoft.com/windows/servercore:2004
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+    -Uri "https://github.com/containous/traefik/releases/download/${VERSION}/traefik_windows-amd64.exe" \
+    -OutFile "/traefik.exe"
+
+EXPOSE 80
+ENTRYPOINT ["/traefik"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Containous" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="$VERSION" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/windows/2004/tmplv2.Dockerfile
+++ b/windows/2004/tmplv2.Dockerfile
@@ -1,0 +1,20 @@
+
+FROM mcr.microsoft.com/windows/servercore:2004
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+    -Uri "https://github.com/containous/traefik/releases/download/${VERSION}/traefik_${VERSION}_windows_amd64.zip" \
+    -OutFile "/traefik.zip"; \
+    Expand-Archive -Path "/traefik.zip" -DestinationPath "/" -Force; \
+    Remove-Item "/traefik.zip" -Force
+
+EXPOSE 80
+ENTRYPOINT ["/traefik"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Containous" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="$VERSION" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"


### PR DESCRIPTION
### What does this PR do?

Add support for Windows containers versions 1903 and 1909.


### Motivation

Windows is more particular about its versioning and how it handles virtualization for containers. By having up-to-date container versions for traefik, this allows users to be able to use the traefik container images with more efficient virtualization in Windows environments.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

First PR to traefik - please don't be shy with comments!