### PR TITLE
make alpine image to support setcap and run traefik to bind 80 with non root user

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.11
-RUN apk --no-cache add ca-certificates tzdata
+RUN apk --no-cache add ca-certificates tzdata libcap
 RUN set -ex; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
@@ -11,7 +11,9 @@ RUN set -ex; \
 	wget --quiet -O /tmp/traefik.tar.gz "https://github.com/containous/traefik/releases/download/v2.3.0-rc5/traefik_v2.3.0-rc5_linux_$arch.tar.gz"; \
 	tar xzvf /tmp/traefik.tar.gz -C /usr/local/bin traefik; \
 	rm -f /tmp/traefik.tar.gz; \
-	chmod +x /usr/local/bin/traefik
+	chmod +x /usr/local/bin/traefik; \
+	setcap 'cap_net_bind_service=+ep' /usr/local/bin/traefik
+	
 COPY entrypoint.sh /
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]

--- a/alpine/tmplv1.Dockerfile
+++ b/alpine/tmplv1.Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:$ALPINE_VERSION
-RUN apk --no-cache add ca-certificates tzdata
+RUN apk --no-cache add ca-certificates tzdata libcap
 RUN set -ex; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
@@ -9,7 +9,9 @@ RUN set -ex; \
 		*) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
 	esac; \
 	wget --quiet -O /usr/local/bin/traefik "https://github.com/containous/traefik/releases/download/$VERSION/traefik_linux-$arch"; \
-	chmod +x /usr/local/bin/traefik
+	chmod +x /usr/local/bin/traefik; \
+	setcap 'cap_net_bind_service=+ep' /usr/local/bin/traefik
+
 COPY entrypoint.sh /
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]

--- a/alpine/tmplv2.Dockerfile
+++ b/alpine/tmplv2.Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:$ALPINE_VERSION
-RUN apk --no-cache add ca-certificates tzdata
+RUN apk --no-cache add ca-certificates tzdata libcap
 RUN set -ex; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
@@ -11,7 +11,9 @@ RUN set -ex; \
 	wget --quiet -O /tmp/traefik.tar.gz "https://github.com/containous/traefik/releases/download/${VERSION}/traefik_${VERSION}_linux_$arch.tar.gz"; \
 	tar xzvf /tmp/traefik.tar.gz -C /usr/local/bin traefik; \
 	rm -f /tmp/traefik.tar.gz; \
-	chmod +x /usr/local/bin/traefik
+	chmod +x /usr/local/bin/traefik; \
+	setcap 'cap_net_bind_service=+ep' /usr/local/bin/traefik
+	
 COPY entrypoint.sh /
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
as #38 mention, to run traefik to bind 80 with non root user is importants for someone who want to run traefik on baremetal k8s cluster.